### PR TITLE
Update Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gozeloglu/cache
 
-go 1.17
+go 1.18


### PR DESCRIPTION
Bump version from `1.17` to `1.18`.

Signed-off-by: Gökhan Özeloğlu <gokhan.ozeloglu@deliveryhero.com>